### PR TITLE
Fix memory leaks in frontend_save_load

### DIFF
--- a/source-dock.cpp
+++ b/source-dock.cpp
@@ -54,6 +54,7 @@ static void frontend_save_load(obs_data_t *save_data, bool saving, void *)
 			obs_data_set_bool(dock, "sceneitems",
 					  it->SceneItemsEnabled());
 			obs_data_array_push_back(docks, dock);
+			obs_data_release(dock);
 		}
 		obs_data_set_array(obj, "docks", docks);
 		obs_data_set_obj(save_data, "source-dock", obj);
@@ -133,6 +134,7 @@ static void frontend_save_load(obs_data_t *save_data, bool saving, void *)
 						tmp->show();
 						obs_source_release(s);
 					}
+					obs_data_release(dock);
 				}
 				obs_frontend_pop_ui_translation();
 				obs_data_array_release(docks);


### PR DESCRIPTION
This pull-requirest will fix memory leaks reported by OBS Studio.

#### Step to reproduce
Add a Source Dock and exit OBS Studio.
Log shows a memory leak message as below.
```
info: Number of memory leaks: 20
```

#### How the code was tested
After applying this change,
- Added a Source Dock and continuously startd and stopped OBS Studio.
- Started OBS Studio and added a Source Dock, then closed OBS Studio.
- Started OBS Studio and removed a Source Dock, then closed OBS Studio.
In above cases, there are no memory leaks reported in the log file.

#### Environment
I tested the code under this environment.
- CentOS 8.4
- OBS Studio 27.0.1-18-g0fd153f9e

I think the memory leak issue would exists in other platforms.